### PR TITLE
use scrollHeight rather than clientHeight

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import Jimp from 'jimp';
 const pageDown = async ( page ) => {
     const isEnd = await page.evaluate( () => {
         window.scrollBy( 0, window.innerHeight );
-        return window.scrollY >= document.body.clientHeight - window.innerHeight;
+        return window.scrollY >= document.documentElement.scrollHeight - window.innerHeight;
     } );
 
     return isEnd;
@@ -15,9 +15,10 @@ const pageDown = async ( page ) => {
 const fullPageScreenshot = async ( page, options = {}, quality = 100) => {
     const { pagesCount, extraPixels, viewport } = await page.evaluate( () => {
         window.scrollTo( 0, 0 );
+        const pageHeight = document.documentElement.scrollHeight;
         return {
-            pagesCount: Math.ceil( document.body.clientHeight / window.innerHeight ),
-            extraPixels: document.body.clientHeight % window.innerHeight * window.devicePixelRatio,
+            pagesCount: Math.ceil( pageHeight / window.innerHeight ),
+            extraPixels: pageHeight % window.innerHeight * window.devicePixelRatio,
             viewport: { height: window.innerHeight * window.devicePixelRatio, width: window.innerWidth * window.devicePixelRatio },
         };
     } );


### PR DESCRIPTION
a page with `body, html { height: 100% } ` will give a clientHeight thats equal to the viewport height.

This fixes that.

here's a nice test page for ya: https://paulirish.github.io/tiny-demos-on-https/pixel-ruler.html?maxPxHeight=20000