### PR TITLE
Fix Unexpected end of input at module.exports.ChunkStream._end error when extraPixels === 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,12 +50,15 @@ const fullPageScreenshot = async (page, options = {}) => {
       if (path) image.write(path);
       return image;
    }
-   // crop last image extra pixels
-   const cropped = await Jimp.read(images.pop())
-      .then((image) => image.crop(0, viewport.height - extraPixels, viewport.width, extraPixels))
-      .then((image) => image.getBufferAsync(Jimp.AUTO));
-
-   images.push(cropped);
+   
+   if (extraPixels > 0) {
+     // crop last image extra pixels
+     const cropped = await Jimp.read(images.pop())
+        .then((image) => image.crop(0, viewport.height - extraPixels, viewport.width, extraPixels))
+        .then((image) => image.getBufferAsync(Jimp.AUTO));
+     
+     images.push(cropped);
+   }
    const mergedImage = await merge(images, { direction: true });
 
    if (path) {


### PR DESCRIPTION
Relates issue: #21
Below is the patch file I'm using in my local computer: `puppeteer-full-page-screenshot+1.2.2.patch`
```
diff --git a/node_modules/puppeteer-full-page-screenshot/lib/index.js b/node_modules/puppeteer-full-page-screenshot/lib/index.js
index 4fa869b..4bfc63e 100644
--- a/node_modules/puppeteer-full-page-screenshot/lib/index.js
+++ b/node_modules/puppeteer-full-page-screenshot/lib/index.js
@@ -71,9 +71,10 @@ const fullPageScreenshot = async (page, options = {}) => {
     return image;
   } // crop last image extra pixels
 
-
-  const cropped = await _jimp.default.read(images.pop()).then(image => image.crop(0, viewport.height - extraPixels, viewport.width, extraPixels)).then(image => image.getBufferAsync(_jimp.default.AUTO));
-  images.push(cropped);
+  if (extraPixels > 0) {
+    const cropped = await _jimp.default.read(images.pop()).then(image => image.crop(0, viewport.height - extraPixels, viewport.width, extraPixels)).then(image => image.getBufferAsync(_jimp.default.AUTO));
+    images.push(cropped);
+  }
   const mergedImage = await (0, _mergeImg.default)(images, {
     direction: true
   });
```